### PR TITLE
add a GitHub action to promote the package from staging to production

### DIFF
--- a/.github/workflows/promote_package_to_production.yml
+++ b/.github/workflows/promote_package_to_production.yml
@@ -1,0 +1,39 @@
+name: Promote emod-api package to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_version:
+        description: 'Package version to promote'
+        required: true
+permissions:
+  actions: write
+
+
+jobs:
+  promote-package-to-production:
+    runs-on: ubuntu-latest
+    environment: Release_Production
+    steps:
+      - name: Set package variables
+        run: |
+          echo "STAGING_REGISTRY=https://packages.idmod.org/api/pypi/idm-pypi-staging/" >> $GITHUB_ENV
+          echo "PROD_REGISTRY=https://packages.idmod.org/api/pypi/idm-pypi-production/" >> $GITHUB_ENV
+          echo "PACKAGE_NAME=emod-api" >> $GITHUB_ENV
+
+      - name: Download package from staging
+        env:
+          PIP_EXTRA_INDEX_URL: https://${{ secrets.STAGING_ARTIFACTORY_USERNAME }}:${{ secrets.STAGING_ARTIFACTORY_PASSWORD }}@packages.idmod.org/api/pypi/idm-pypi-staging/simple/
+        run: |
+          pip install --upgrade pip
+          pip download --index-url $PIP_EXTRA_INDEX_URL --no-deps ${{ env.PACKAGE_NAME }}==${{ github.event.inputs.package_version }} -d ./dist
+      - name: Install twine
+        run: pip install twine
+
+      - name: Upload to production PyPI
+        run: |
+          twine upload --verbose \
+            --repository-url ${{ env.PROD_REGISTRY }} \
+            --username ${{ secrets.PROD_ARTIFACTORY_USERNAME }} \
+            --password ${{ secrets.PROD_ARTIFACTORY_PASSWORD }} \
+            ./dist/*.whl

--- a/.github/workflows/promote_package_to_production.yml
+++ b/.github/workflows/promote_package_to_production.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           echo "STAGING_REGISTRY=https://packages.idmod.org/api/pypi/idm-pypi-staging/" >> $GITHUB_ENV
           echo "PROD_REGISTRY=https://packages.idmod.org/api/pypi/idm-pypi-production/" >> $GITHUB_ENV
-          echo "PACKAGE_NAME=emod-api" >> $GITHUB_ENV
+          echo "PACKAGE_NAME=emod_api" >> $GITHUB_ENV
 
       - name: Download package from staging
         env:
@@ -27,6 +27,17 @@ jobs:
         run: |
           pip install --upgrade pip
           pip download --index-url $PIP_EXTRA_INDEX_URL --no-deps ${{ env.PACKAGE_NAME }}==${{ github.event.inputs.package_version }} -d ./dist
+
+      - name: install staging package
+        run: |
+          pip install ./dist/${{ env.PACKAGE_NAME }}-${{ github.event.inputs.package_version }}-py3-none-any.whl
+      
+      - name: run unit tests
+        run: |
+          pip install -r requirements.txt
+          python -m unittest discover .
+        working-directory: ./tests
+
       - name: Install twine
         run: pip install twine
 


### PR DESCRIPTION
- The release workflow will be manually triggered using workflow_dispatch.
- It will be accessible only to users with write permissions to the repository.
- The workflow will be tied to a protected environment, which will require manual approval before deployment.
- I’ll add the four of us as required reviewers for that environment.
- When the release workflow is triggered, one of us will need to review and approve the deployment, which will then promote the package to production.