### PR TITLE
Stop passing schema path

### DIFF
--- a/emod_api/campaign.py
+++ b/emod_api/campaign.py
@@ -6,6 +6,7 @@ You use this simple campaign builder by importing it, adding valid events via "a
 import json
 
 schema_path = None
+schema_json = None
 campaign_dict = {"Events": [], "Use_Defaults": 1}
 pubsub_signals_subbing = []
 pubsub_signals_pubbing = []
@@ -32,7 +33,7 @@ def reset():
     del (custom_node_events[:])
     event_map = {}
     from emod_api import schema_to_class as s2c
-    s2c.schema_cache = None
+    s2c.clear_schema_cache()
     del (implicits[:])
 
 
@@ -42,22 +43,20 @@ def set_schema(schema_path_in):
     "start_building_campaign" function.
 
     Args:
-
         schema_path_in. The path to a schema.json.
     Returns:
         Nothing
     """
     reset()
-    global schema_path
+    global schema_path, schema_json
+
     schema_path = schema_path_in
+    with open(schema_path_in) as schema_file:
+        schema_json = json.load(schema_file)
 
 
 def get_schema():
-    schema = None
-    if schema_path:
-        with open(schema_path) as schema_file:
-            schema = json.load(schema_file)
-    return schema
+    return schema_json
 
 
 def add(event, name=None, first=False):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -556,8 +556,11 @@ class ConfigTest(unittest.TestCase):
             "idmType:WaningEffectCollection"
         ]
 
+        with open(schema_path) as fid01:
+            schema_json = json.load(fid01)
+
         for idmtype in mytypes:
-            type_dict = s2c.get_class_with_defaults( idmtype, schema_path ) # checking for error
+            type_dict = s2c.get_class_with_defaults( idmtype, schema_json=schema_json ) # checking for error
 
     def compare_config_with_po(self, config, po, default):
         for key, value in config.items():
@@ -577,7 +580,10 @@ class ConfigTest(unittest.TestCase):
 class ReadOnlyDictTest(unittest.TestCase):
     def test_schema_to_class(self):
         schema_path = manifest.common_schema_path
-        coordinator = s2c.get_class_with_defaults("StandardEventCoordinator", schema_path)
+        with open(schema_path) as fid01:
+            schema_json = json.load(fid01)
+
+        coordinator = s2c.get_class_with_defaults("StandardEventCoordinator", schema_json=schema_json)
 
         coordinator.Number_Repetitions = 123    # doesn't raise an exception
 


### PR DESCRIPTION
One step on the way toward not having a schema cache.
Ref: https://github.com/EMOD-Hub/emod-api/issues/20

- Adds schema_json to campaign module; campaign module should use schema_json, not pass along the path
- Test changes