### PR TITLE
Simplify schema processing of interventions; add tests

### DIFF
--- a/emod_api/schema_to_class.py
+++ b/emod_api/schema_to_class.py
@@ -388,7 +388,7 @@ def get_class_with_defaults(classname, schema_path=None, schema_json=None):
 
     # abstract_key7 = "idmAbstractType:IndividualIntervention"
     elif (abstract_key7 in schema_idm and classname in schema_idm[abstract_key7]):
-        schema_blob = schema_idm[abstract_key7][iv_type][classname]
+        schema_blob = schema_idm[abstract_key7][classname]
         ret_json["class"] = schema_blob["class"]
         for key_str in schema_blob.keys():
             if key_str in ["class", "Sim_Types"]:
@@ -397,7 +397,7 @@ def get_class_with_defaults(classname, schema_path=None, schema_json=None):
 
     # abstract_key8 = "idmAbstractType:NodeIntervention"
     elif (abstract_key8 in schema_idm and classname in schema_idm[abstract_key8]):
-        schema_blob = schema_idm[abstract_key8][iv_type][classname]
+        schema_blob = schema_idm[abstract_key8][classname]
         ret_json["class"] = schema_blob["class"]
         for key_str in schema_blob.keys():
             if key_str in ["class", "Sim_Types"]:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -72,7 +72,7 @@ class TestSchemaCommon():
                 return True
             if (':IndividualIntervention' in key_in or ':NodeIntervention' in key_in):
                 for iv_obj_name in val_in:
-                    # For every parameter defined in an inteverntion
+                    # For every parameter defined in an intervention
                     iv_obj = val_in[iv_obj_name]
                     for iv_param_name in iv_obj:
                         if (iv_param_name == 'class' or iv_param_name == 'Sim_Types'):
@@ -94,7 +94,7 @@ class TestSchemaCommon():
                 return True
             if (':IndividualIntervention' in key_in or ':NodeIntervention' in key_in):
                 for iv_obj_name in val_in:
-                    # For every parameter defined in an inteverntion
+                    # For every parameter defined in an intervention
                     iv_obj = val_in[iv_obj_name]
                     for iv_param_name in iv_obj:
                         if (iv_param_name == 'class' or iv_param_name == 'Sim_Types'):
@@ -102,9 +102,7 @@ class TestSchemaCommon():
                         iv_param_obj = iv_obj[iv_param_name]
                         if ('default' not in iv_param_obj and 'type' in iv_param_obj):
                             type_str = iv_param_obj['type']
-                            if (type_str.startswith('idmType')):
-                                return True
-                            elif (type_str.startswith('idmAbstractType')):
+                            if (type_str.startswith('idmType') or type_str.startswith('idmAbstractType')):
                                 return True
                             else:
                                 return False


### PR DESCRIPTION
Additional simplifications in `get_class_with_defaults`

- Always exclude `Sim_Types' key
- Add tests for the presence of `default` and `type` keys.

Should wait for other PRs:
https://github.com/EMOD-Hub/emodpy/pull/48
