### PR TITLE
Demographic file output cleaning

### DIFF
--- a/emod_api/demographics/demographics_base.py
+++ b/emod_api/demographics/demographics_base.py
@@ -162,11 +162,11 @@ class DemographicsBase(BaseInputFile):
 
     @property
     def _all_node_names(self) -> list[int]:
-        return [node.name for node in self._all_nodes]
+        return [node.name for node in self._all_nodes if node.name is not None]
 
     @property
     def _all_nodes_by_name(self) -> dict[int, Node]:
-        return {node.name: node for node in self._all_nodes}
+        return {node.name: node for node in self._all_nodes if node.name is not None}
 
     @property
     def _all_node_ids(self) -> list[int]:

--- a/emod_api/demographics/demographics_base.py
+++ b/emod_api/demographics/demographics_base.py
@@ -22,6 +22,8 @@ class DemographicsBase(BaseInputFile):
         :py:obj:`emod_api:emod_api.demographics.DemographicsOverlay`.
     """
 
+    DEFAULT_NODE_NAME = 'default_node'
+
     class UnknownNodeException(ValueError):
         pass
 
@@ -49,6 +51,7 @@ class DemographicsBase(BaseInputFile):
         # Build the default node if not provided and then perform some setup/verification
         default_node = self._generate_default_node() if default_node is None else default_node
         self.default_node = default_node
+        self.default_node.name = self.DEFAULT_NODE_NAME
         if self.default_node.id != 0:
             raise InvalidNodeIdException(f"Default nodes must have an id of 0. It is {self.default_node.id} .")
         self.metadata = self.generate_headers()
@@ -61,7 +64,7 @@ class DemographicsBase(BaseInputFile):
         self.verify_demographics_integrity()
 
     def _generate_default_node(self) -> Node:
-        default_node = Node(lat=0, lon=0, pop=0, forced_id=0)
+        default_node = Node(lat=0, lon=0, pop=0, name=self.DEFAULT_NODE_NAME, forced_id=0)
         # TODO: remove the following setting of birth_rate on the default node once this EMOD binary issue is fixed
         #  https://github.com/InstituteforDiseaseModeling/DtkTrunk/issues/4009
         default_node.birth_rate = 0

--- a/emod_api/demographics/demographics_base.py
+++ b/emod_api/demographics/demographics_base.py
@@ -145,7 +145,7 @@ class DemographicsBase(BaseInputFile):
 
     def _verify_node_name_uniqueness(self):
         nodes = self._all_nodes
-        node_names = [node.name for node in nodes]
+        node_names = [node.name for node in nodes if node.name is not None]
         duplicate_items = self._duplicates_check(items=node_names)
         if len(duplicate_items) > 0:
             duplicate_items_str = [str(item) for item in duplicate_items]

--- a/emod_api/demographics/demographics_base.py
+++ b/emod_api/demographics/demographics_base.py
@@ -161,11 +161,11 @@ class DemographicsBase(BaseInputFile):
         return all_nodes
 
     @property
-    def _all_node_names(self) -> list[int]:
+    def _all_node_names(self) -> list[str]:
         return [node.name for node in self._all_nodes if node.name is not None]
 
     @property
-    def _all_nodes_by_name(self) -> dict[int, Node]:
+    def _all_nodes_by_name(self) -> dict[str, Node]:
         return {node.name: node for node in self._all_nodes if node.name is not None}
 
     @property

--- a/emod_api/demographics/demographics_base.py
+++ b/emod_api/demographics/demographics_base.py
@@ -22,8 +22,6 @@ class DemographicsBase(BaseInputFile):
         :py:obj:`emod_api:emod_api.demographics.DemographicsOverlay`.
     """
 
-    DEFAULT_NODE_NAME = 'default_node'
-
     class UnknownNodeException(ValueError):
         pass
 
@@ -51,7 +49,6 @@ class DemographicsBase(BaseInputFile):
         # Build the default node if not provided and then perform some setup/verification
         default_node = self._generate_default_node() if default_node is None else default_node
         self.default_node = default_node
-        self.default_node.name = self.DEFAULT_NODE_NAME
         if self.default_node.id != 0:
             raise InvalidNodeIdException(f"Default nodes must have an id of 0. It is {self.default_node.id} .")
         self.metadata = self.generate_headers()
@@ -64,7 +61,7 @@ class DemographicsBase(BaseInputFile):
         self.verify_demographics_integrity()
 
     def _generate_default_node(self) -> Node:
-        default_node = Node(lat=0, lon=0, pop=0, name=self.DEFAULT_NODE_NAME, forced_id=0)
+        default_node = Node(lat=0, lon=0, pop=0, forced_id=0)
         # TODO: remove the following setting of birth_rate on the default node once this EMOD binary issue is fixed
         #  https://github.com/InstituteforDiseaseModeling/DtkTrunk/issues/4009
         default_node.birth_rate = 0

--- a/emod_api/demographics/node.py
+++ b/emod_api/demographics/node.py
@@ -70,7 +70,7 @@ class Node(Updateable):
         self.node_attributes.name = value
 
     def __repr__(self):
-        name = self.node_attributes.name or "(unnamed)"
+        name = self.node_attributes.name or str(self.id)
         return f"{name} - ({self.node_attributes.latitude},{self.node_attributes.longitude})"
 
     def has_individual_property(self, property_key: str) -> bool:

--- a/emod_api/demographics/node.py
+++ b/emod_api/demographics/node.py
@@ -145,7 +145,9 @@ class Node(Updateable):
         nodeid = data["NodeID"]
         node_attributes_dict = dict(data.get("NodeAttributes"))
         attributes = data["NodeAttributes"]
-        name = attributes.pop("Name", None)
+        name = attributes.get("Name", None)
+        if name is None:
+            name = attributes.get("FacilityName", None)
         individual_attributes_dict = data.get("IndividualAttributes")
         individual_properties_dict = data.get("IndividualProperties")
 

--- a/emod_api/demographics/node.py
+++ b/emod_api/demographics/node.py
@@ -57,14 +57,8 @@ class Node(Updateable):
         if node_attributes is not None:
             self.node_attributes.update(node_attributes)
 
-        if name is None:
-            # if no node name was explicitly provided, we need to figure out how to name the node
-            if node_attributes is None or node_attributes.name is None:
-                # if no node_attributes object was provided with a name, use a standard default name
-                name = f"node{str(self.id)}"
-            else:
-                # if a name was specified for use via the node_attributes parameter, use it
-                name = node_attributes.name
+        if name is None and node_attributes is not None and node_attributes.name is not None:
+            name = node_attributes.name
         self.name = name
 
     @property
@@ -76,7 +70,8 @@ class Node(Updateable):
         self.node_attributes.name = value
 
     def __repr__(self):
-        return f"{self.node_attributes.name} - ({self.node_attributes.latitude},{self.node_attributes.longitude})"
+        name = self.node_attributes.name or "(unnamed)"
+        return f"{name} - ({self.node_attributes.latitude},{self.node_attributes.longitude})"
 
     def has_individual_property(self, property_key: str) -> bool:
         return self.individual_properties.has_individual_property(property_key=property_key)
@@ -95,7 +90,9 @@ class Node(Updateable):
              "NodeAttributes": self.node_attributes.to_dict()}
 
         if self.individual_attributes:
-            d["IndividualAttributes"] = self.individual_attributes.to_dict()
+            ia_dict = self.individual_attributes.to_dict()
+            if ia_dict:
+                d["IndividualAttributes"] = ia_dict
 
         if self.individual_properties:
             ip_dict = {"IndividualProperties": []}
@@ -104,6 +101,7 @@ class Node(Updateable):
             d.update(ip_dict)
 
         d.update(self.meta)
+
         return d
 
     def to_tuple(self):
@@ -147,7 +145,7 @@ class Node(Updateable):
         nodeid = data["NodeID"]
         node_attributes_dict = dict(data.get("NodeAttributes"))
         attributes = data["NodeAttributes"]
-        name = attributes.pop("FacilityName", nodeid)
+        name = attributes.pop("Name", None)
         individual_attributes_dict = data.get("IndividualAttributes")
         individual_properties_dict = data.get("IndividualProperties")
 

--- a/emod_api/demographics/overlay_node.py
+++ b/emod_api/demographics/overlay_node.py
@@ -14,3 +14,28 @@ class OverlayNode(Node):
                  **kwargs
                  ):
         super().__init__(lat=latitude, lon=longitude, pop=initial_population, forced_id=node_id, **kwargs)
+
+    def to_dict(self) -> dict:
+        """
+        Translate node structure to a dictionary for EMOD
+        """
+        d = {"NodeID": self.id}
+
+        if self.node_attributes:
+            na_dict = self.node_attributes.to_dict()
+            if na_dict:
+                d["NodeAttributes"] = na_dict
+
+        if self.individual_attributes:
+            ia_dict = self.individual_attributes.to_dict()
+            if ia_dict:
+                d["IndividualAttributes"] = ia_dict
+
+        if self.individual_properties:
+            ip_dict = {"IndividualProperties": []}
+            for ip in self.individual_properties:
+                ip_dict["IndividualProperties"].append(ip.to_dict())
+            d.update(ip_dict)
+
+        d.update(self.meta)
+        return d

--- a/emod_api/demographics/overlay_node.py
+++ b/emod_api/demographics/overlay_node.py
@@ -38,4 +38,5 @@ class OverlayNode(Node):
             d.update(ip_dict)
 
         d.update(self.meta)
+
         return d

--- a/emod_api/demographics/properties_and_attributes.py
+++ b/emod_api/demographics/properties_and_attributes.py
@@ -722,12 +722,12 @@ class NodeAttributes(Updateable):
         self.latitude = node_attributes.get("Latitude")
         self.longitude = node_attributes.get("Longitude")
         self.metadata = node_attributes.get("Metadata")
-        self.name = node_attributes.get("FacilityName")
+        self.name = node_attributes.get("Name")
         self.infectivity_multiplier = node_attributes.get("InfectivityMultiplier")
         self.node_property_values = node_attributes.get("NodePropertyValues")
 
         # Legacy keys
-        key_list = ["Airport", "Region", "Seaport"]
+        key_list = ["Airport", "Region", "Seaport", "FacilityName"]
         for key_name in key_list:
             key_val = node_attributes.get(key_name)
             if key_val is not None:
@@ -755,7 +755,7 @@ class NodeAttributes(Updateable):
             node_attributes.update({"InitialPopulation": int(self.initial_population)})
 
         if self.name:
-            node_attributes.update({"FacilityName": self.name})
+            node_attributes.update({"Name": self.name})
 
         if self.larval_habitat_multiplier is not None:
             node_attributes.update({"LarvalHabitatMultiplier": self.larval_habitat_multiplier})

--- a/emod_api/demographics/properties_and_attributes.py
+++ b/emod_api/demographics/properties_and_attributes.py
@@ -754,7 +754,7 @@ class NodeAttributes(Updateable):
         if self.initial_population is not None:
             node_attributes.update({"InitialPopulation": int(self.initial_population)})
 
-        if self.name:
+        if self.name is not None:
             node_attributes.update({"Name": self.name})
 
         if self.larval_habitat_multiplier is not None:

--- a/tests/data/demographics/Namawala_four_node_demographics_for_Thomas.json
+++ b/tests/data/demographics/Namawala_four_node_demographics_for_Thomas.json
@@ -181,7 +181,7 @@
             "Airport": 0,
             "Altitude": 0,
             "BirthRate": 0.0001,
-            "FacilityName": 340461476,
+            "Name": 340461476,
             "InitialPopulation": 1000,
             "LarvalHabitatMultiplier": [
                {
@@ -273,7 +273,7 @@
             "Airport": 0,
             "Altitude": 0,
             "BirthRate": 0.0001,
-            "FacilityName": 340461477,
+            "Name": 340461477,
             "InitialPopulation": 1000,
             "InitialVectorsPerSpecies": {
                "arabiensis": 12,
@@ -341,7 +341,7 @@
             "Airport": 0,
             "Altitude": 0,
             "BirthRate": 0.0001,
-            "FacilityName": 340461478,
+            "Name": 340461478,
             "InitialPopulation": 1000,
             "InitialVectorsPerSpecies": {
                "arabiensis": 12,
@@ -409,7 +409,7 @@
             "Airport": 0,
             "Altitude": 0,
             "BirthRate": 0.000129034,
-            "FacilityName": 340461479,
+            "Name": 340461479,
             "InitialPopulation": 1000,
             "InitialVectorsPerSpecies": {
                "arabiensis": 10,

--- a/tests/data/demographics/Namawala_four_node_demographics_for_Thomas.json
+++ b/tests/data/demographics/Namawala_four_node_demographics_for_Thomas.json
@@ -75,7 +75,7 @@
          "Airport": 0,
          "Altitude": 0,
          "BirthRate": 0.0002,
-         "FacilityName": "default_node",
+         "Name": "default_node",
          "InitialPopulation": 1000,
          "InitialVectorsPerSpecies": {
             "arabiensis": 500,

--- a/tests/data/demographics/single_node_demographics.json
+++ b/tests/data/demographics/single_node_demographics.json
@@ -70,7 +70,7 @@
          "Airport": 0,
          "Altitude": 0,
          "BirthRate": 36.30287175670945,
-         "FacilityName": "default_node",
+         "Name": "default_node",
          "Metadata": {
             "AbovePoverty": 0.5,
             "BirthRateSource": "World Bank",

--- a/tests/data/demographics/single_node_demographics.json
+++ b/tests/data/demographics/single_node_demographics.json
@@ -245,7 +245,7 @@
          },
          "NodeAttributes": {
             "BirthRate": 0.10663013698630137,
-            "FacilityName": 1,
+            "Name": 1,
             "InitialPopulation": 1000,
             "Latitude": 8.5,
             "Longitude": -10.0,

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -134,14 +134,8 @@ class DemographicsTest(unittest.TestCase):
         nodes = [mars, venus]
         demographics = Demographics(nodes=nodes, default_node=planet)
 
-        # just getting some nodes, also checking explicit default node request, too.
-        nodes = demographics.get_nodes_by_name(node_names=['Mars', 'default_node'])
-        expected = {planet.name: planet, mars.name: mars}
-        self.assertEqual(nodes, expected)
-
-        # verify that a node name of None will yield the default node
-        nodes = demographics.get_nodes_by_name(node_names=['Mars', None])
-        expected = {planet.name: planet, mars.name: mars}
+        nodes = demographics.get_nodes_by_name(node_names=['Mars'])
+        expected = {mars.name: mars}
         self.assertEqual(nodes, expected)
 
         nodes = demographics.get_nodes_by_name(node_names=None)
@@ -170,15 +164,6 @@ class DemographicsTest(unittest.TestCase):
         mars = Node(lat=0, lon=0, pop=100, name='Mars', forced_id=1)
         venus = Node(lat=0, lon=0, pop=100, name='Mars', forced_id=2)
         planet = Node(lat=0, lon=0, pop=100, forced_id=0)
-        nodes = [mars, venus]
-        self.assertRaises(DemographicsBase.DuplicateNodeNameException,
-                          Demographics, nodes=nodes, default_node=planet)
-
-        # mixing it up a bit to ensure that the default node is included in the error reporting. As well as
-        # ensuring that one gets duplicate errors even when requesting a non-duplicated node.
-        mars = Node(lat=0, lon=0, pop=100, name='Mars', forced_id=1)
-        venus = Node(lat=0, lon=0, pop=100, name='default_node', forced_id=2)
-        planet = Node(lat=0, lon=0, pop=100, forced_id=0)  # gets an implicit name 'default_node'
         nodes = [mars, venus]
         self.assertRaises(DemographicsBase.DuplicateNodeNameException,
                           Demographics, nodes=nodes, default_node=planet)
@@ -993,8 +978,7 @@ class DemographicsOverlayTest(unittest.TestCase):
                     }
                 },
                 "NodeAttributes": {
-                    "BirthRate": 0,
-                    "Name": "default_node"
+                    "BirthRate": 0
                 }
             },
             "Metadata": {
@@ -1089,8 +1073,7 @@ class DemographicsOverlayTest(unittest.TestCase):
                 },
                 "NodeAttributes": {
                     "BirthRate": 0.1,
-                    "GrowthRate": 1.01,
-                    "Name": "default_node"
+                    "GrowthRate": 1.01
                 }
             },
             "Metadata": {
@@ -1136,7 +1119,7 @@ class DemographicsOverlayTest(unittest.TestCase):
         population_groups = [mort_vec_X, mort_year]
 
         # Vital dynamics overlays -- this is what we expect emod-api DemographicsOverlay (below) to generate
-        vd_over_dict['Defaults'] = {'NodeID': 0, 'IndividualAttributes': dict(), 'NodeAttributes': {'BirthRate': 0, 'Name': 'default_node'}}
+        vd_over_dict['Defaults'] = {'NodeID': 0, 'IndividualAttributes': dict(), 'NodeAttributes': {'BirthRate': 0}}
 
         vd_over_dict['Nodes'] = [{'NodeID': node_obj.forced_id} for node_obj in node_list]
 

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -1514,3 +1514,67 @@ class NodePropertiesDemographicsTest(unittest.TestCase):
         node100 = [n for n in d["Nodes"] if n["NodeID"] == 100][0]
         self.assertEqual(node100["NodeAttributes"]["NodePropertyValues"],
                          ["Place:RURAL", "InterventionStatus:SPRAYED_B"])
+
+
+class OverlayNodeToDictTest(unittest.TestCase):
+    """Tests for the OverlayNode.to_dict() override that omits empty/None sections."""
+
+    def test_to_dict_node_id_only(self):
+        # OverlayNode with no lat/lon/pop/attributes should produce only NodeID
+        node = OverlayNode(node_id=5)
+        self.assertEqual(node.to_dict(), {"NodeID": 5})
+
+    def test_to_dict_omits_node_attributes_when_empty(self):
+        # Empty NodeAttributes produces an empty dict, which should be omitted
+        node = OverlayNode(node_id=3, node_attributes=NodeAttributes())
+        result = node.to_dict()
+        self.assertNotIn("NodeAttributes", result)
+
+    def test_to_dict_includes_node_attributes_when_populated(self):
+        # Non-empty NodeAttributes should be written to the dict
+        node = OverlayNode(node_id=3, node_attributes=NodeAttributes(birth_rate=0.1, initial_population=1000))
+        result = node.to_dict()
+        self.assertIn("NodeAttributes", result)
+        self.assertEqual(result["NodeAttributes"]["BirthRate"], 0.1)
+        self.assertEqual(result["NodeAttributes"]["InitialPopulation"], 1000)
+
+    def test_to_dict_includes_node_attributes_when_lat_lon_provided(self):
+        # lat/lon are passed as positional args to OverlayNode
+        node = OverlayNode(node_id=8, latitude=10.5, longitude=20.5)
+        result = node.to_dict()
+        self.assertIn("NodeAttributes", result)
+        self.assertEqual(result["NodeAttributes"]["Latitude"], 10.5)
+        self.assertEqual(result["NodeAttributes"]["Longitude"], 20.5)
+
+    def test_to_dict_omits_individual_attributes_when_empty(self):
+        # Default IndividualAttributes is empty; should not appear in output
+        node = OverlayNode(node_id=2)
+        result = node.to_dict()
+        self.assertNotIn("IndividualAttributes", result)
+
+    def test_to_dict_includes_individual_attributes_when_populated(self):
+        # IndividualAttributes with set values should be written to the dict
+        ia = IndividualAttributes(age_distribution_flag=1, age_distribution1=365, age_distribution2=3650)
+        node = OverlayNode(node_id=4, individual_attributes=ia)
+        result = node.to_dict()
+        self.assertIn("IndividualAttributes", result)
+        self.assertEqual(result["IndividualAttributes"]["AgeDistributionFlag"], 1)
+
+    def test_to_dict_includes_individual_properties_when_set(self):
+        # IndividualProperties with an entry should be written to the dict
+        ip = IndividualProperties()
+        ip.add(IndividualProperty(property="Risk", values=["High", "Low"],
+                                  initial_distribution=[0.3, 0.7],
+                                  transmission_matrix=[[1, 0], [0, 1]]))
+        node = OverlayNode(node_id=6, individual_properties=ip)
+        result = node.to_dict()
+        self.assertIn("IndividualProperties", result)
+        self.assertEqual(len(result["IndividualProperties"]), 1)
+        self.assertEqual(result["IndividualProperties"][0]["Property"], "Risk")
+
+    def test_node_always_writes_node_attributes_contrast(self):
+        # Regular Node.to_dict() always includes NodeAttributes; OverlayNode does not when empty
+        overlay_node = OverlayNode(node_id=1)
+        regular_node = Node(lat=0, lon=0, pop=0, forced_id=1)
+        self.assertNotIn("NodeAttributes", overlay_node.to_dict())
+        self.assertIn("NodeAttributes", regular_node.to_dict())

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -134,8 +134,14 @@ class DemographicsTest(unittest.TestCase):
         nodes = [mars, venus]
         demographics = Demographics(nodes=nodes, default_node=planet)
 
-        nodes = demographics.get_nodes_by_name(node_names=['Mars'])
-        expected = {mars.name: mars}
+        # just getting some nodes, also checking explicit default node request, too.
+        nodes = demographics.get_nodes_by_name(node_names=['Mars', 'default_node'])
+        expected = {planet.name: planet, mars.name: mars}
+        self.assertEqual(nodes, expected)
+
+        # verify that a node name of None will yield the default node
+        nodes = demographics.get_nodes_by_name(node_names=['Mars', None])
+        expected = {planet.name: planet, mars.name: mars}
         self.assertEqual(nodes, expected)
 
         nodes = demographics.get_nodes_by_name(node_names=None)
@@ -168,6 +174,15 @@ class DemographicsTest(unittest.TestCase):
         self.assertRaises(DemographicsBase.DuplicateNodeNameException,
                           Demographics, nodes=nodes, default_node=planet)
 
+        # mixing it up a bit to ensure that the default node is included in the error reporting. As well as
+        # ensuring that one gets duplicate errors even when requesting a non-duplicated node.
+        mars = Node(lat=0, lon=0, pop=100, name='Mars', forced_id=1)
+        venus = Node(lat=0, lon=0, pop=100, name='default_node', forced_id=2)
+        planet = Node(lat=0, lon=0, pop=100, forced_id=0)  # gets an implicit name 'default_node'
+        nodes = [mars, venus]
+        self.assertRaises(DemographicsBase.DuplicateNodeNameException,
+                          Demographics, nodes=nodes, default_node=planet)
+
         # ensure json-dumping of demographics catches duplicates, too
         venus.name = 'Venus'  # make it valid
         demographics = Demographics(nodes=[mars, venus], default_node=planet)
@@ -179,6 +194,7 @@ class DemographicsTest(unittest.TestCase):
 
         default_node = demographics.default_node
 
+        self.assertEqual(Demographics.DEFAULT_NODE_NAME, default_node.name)
         self.assertEqual(0, default_node.id)
 
         # check default node attributes
@@ -978,7 +994,8 @@ class DemographicsOverlayTest(unittest.TestCase):
                     }
                 },
                 "NodeAttributes": {
-                    "BirthRate": 0
+                    "BirthRate": 0,
+                    "Name": "default_node"
                 }
             },
             "Metadata": {
@@ -1073,7 +1090,8 @@ class DemographicsOverlayTest(unittest.TestCase):
                 },
                 "NodeAttributes": {
                     "BirthRate": 0.1,
-                    "GrowthRate": 1.01
+                    "GrowthRate": 1.01,
+                    "Name": "default_node"
                 }
             },
             "Metadata": {
@@ -1119,7 +1137,7 @@ class DemographicsOverlayTest(unittest.TestCase):
         population_groups = [mort_vec_X, mort_year]
 
         # Vital dynamics overlays -- this is what we expect emod-api DemographicsOverlay (below) to generate
-        vd_over_dict['Defaults'] = {'NodeID': 0, 'IndividualAttributes': dict(), 'NodeAttributes': {'BirthRate': 0}}
+        vd_over_dict['Defaults'] = {'NodeID': 0, 'IndividualAttributes': dict(), 'NodeAttributes': {'BirthRate': 0, 'Name': 'default_node'}}
 
         vd_over_dict['Nodes'] = [{'NodeID': node_obj.forced_id} for node_obj in node_list]
 

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -194,7 +194,6 @@ class DemographicsTest(unittest.TestCase):
 
         default_node = demographics.default_node
 
-        self.assertEqual(Demographics.DEFAULT_NODE_NAME, default_node.name)
         self.assertEqual(0, default_node.id)
 
         # check default node attributes
@@ -220,7 +219,6 @@ class DemographicsTest(unittest.TestCase):
         self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['Latitude'], 0)
         self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['Longitude'], 0)
         self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['InitialPopulation'], 1e6)
-        self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['FacilityName'], "Erewhon")
         self.assertEqual(demog_json['Nodes'][0]['NodeID'], 1)
         self.assertEqual(len(demog.implicits), 0)
 
@@ -239,7 +237,6 @@ class DemographicsTest(unittest.TestCase):
         self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['Latitude'], lat)
         self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['Longitude'], lon)
         self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['InitialPopulation'], pop)
-        self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['FacilityName'], name)
         self.assertEqual(demog_json['Nodes'][0]['NodeID'], forced_id)
         self.assertEqual(len(demog.implicits), 0)
 
@@ -261,7 +258,6 @@ class DemographicsTest(unittest.TestCase):
         self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['Latitude'], lat)
         self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['Longitude'], lon)
         self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['InitialPopulation'], pop)
-        self.assertEqual(demog_json['Nodes'][0]['NodeAttributes']['FacilityName'], name)
         self.assertEqual(demog_json['Nodes'][0]['NodeID'], forced_id)
         self.assertEqual(len(demog.implicits), 0)
 
@@ -381,19 +377,8 @@ class DemographicsTest(unittest.TestCase):
 
         self.maxDiff = None
 
-        if "NodeAttributes" in demog_json_original['Defaults']:
-            FacilityName = demog_json_original['Defaults']["NodeAttributes"].pop("FacilityName", None)
-            self.assertEqual(FacilityName, demog_json_after_passthrough['Defaults']["NodeAttributes"].pop("FacilityName", None))
-
         for node_original, node_new in zip(demog_json_original['Nodes'], demog_json_after_passthrough['Nodes']):
             if "NodeAttributes" in node_original:
-                FacilityName = node_original["NodeAttributes"].pop("FacilityName", None)
-
-                if FacilityName:
-                    self.assertEqual(FacilityName, node_new["NodeAttributes"].pop("FacilityName", None))
-                else:
-                    NodeID = node_original['NodeID']
-                    self.assertEqual(NodeID, node_new["NodeAttributes"].pop("FacilityName", None))
 
                 self.assertEqual(node_original.pop("NodeID"), node_new.pop("NodeID"))   # NodeID must exist, return no default
 
@@ -1009,7 +994,7 @@ class DemographicsOverlayTest(unittest.TestCase):
                 },
                 "NodeAttributes": {
                     "BirthRate": 0,
-                    "FacilityName": "default_node"
+                    "Name": "default_node"
                 }
             },
             "Metadata": {
@@ -1105,7 +1090,7 @@ class DemographicsOverlayTest(unittest.TestCase):
                 "NodeAttributes": {
                     "BirthRate": 0.1,
                     "GrowthRate": 1.01,
-                    "FacilityName": "default_node"
+                    "Name": "default_node"
                 }
             },
             "Metadata": {
@@ -1151,7 +1136,7 @@ class DemographicsOverlayTest(unittest.TestCase):
         population_groups = [mort_vec_X, mort_year]
 
         # Vital dynamics overlays -- this is what we expect emod-api DemographicsOverlay (below) to generate
-        vd_over_dict['Defaults'] = {'NodeID': 0, 'IndividualAttributes': dict(), 'NodeAttributes': {'BirthRate': 0, 'FacilityName': 'default_node'}}
+        vd_over_dict['Defaults'] = {'NodeID': 0, 'IndividualAttributes': dict(), 'NodeAttributes': {'BirthRate': 0, 'Name': 'default_node'}}
 
         vd_over_dict['Nodes'] = [{'NodeID': node_obj.forced_id} for node_obj in node_list]
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -93,7 +93,7 @@ class NodeTest(unittest.TestCase):
         node = Node(lat=0,lon=0,pop=100, individual_attributes=individual_attributes_1)
         self.assertEqual(node.to_dict()["IndividualAttributes"]["user_defined_2"], 2)
         node = Node(lat=0,lon=0,pop=100, individual_attributes=individual_attributes_2)
-        self.assertNotIn("user_defined_2", node.to_dict()["IndividualAttributes"])
+        self.assertNotIn("IndividualAttributes", node.to_dict())
 
         ips = [IndividualProperty(property='cloudy', values=["yes", "no"], initial_distribution=[0.5, 0.5])]
         individual_properties_1 = IndividualProperties(ips)
@@ -118,7 +118,7 @@ class NodeTest(unittest.TestCase):
         node_3 = Node(lat=1, lon=2, pop=100, node_attributes=node_attributes, individual_attributes=individual_attributes)
 
         self.assertEqual(node_1.to_dict()["NodeAttributes"]["Test_1"], 1)
-        self.assertTrue("Test_2" not in node_1.to_dict()["IndividualAttributes"])
+        self.assertTrue("IndividualAttributes" not in node_1.to_dict())
 
         self.assertTrue("Test_1" not in node_2.to_dict()["NodeAttributes"])
         self.assertEqual(node_2.to_dict()["IndividualAttributes"]["Test_2"], 2)


### PR DESCRIPTION
A few changes to not write things to the demographic file if they're not getting used. (My file size can get large-ish).

1. A node name is metadata. Previously, every node would get assigned a `"FacilityName"` but it's not something used by EMOD. New behavior is `None` (the Python type) is fine and if a node name is `None` (the Python type) then no name is written. If the name is not `None` then there is a name written, but it's using the key string `"Name"` instead of `"FacilityName"`. The api also enforces a uniqueness requirement for the names, which has been retained, so if there is a name, it needs to be unique.
2. A node's `"IndividualAttributes"` are only written if there are individual attributes to write. If it's an empty dict, then nothing is written. EMOD never processes the `"IndividualAttributes"` object, it only ever looks inside if something is expected (e.g., `"InnateImmuneDistributionFlag"`), so a Demographics file with no `"IndividualAttributes"` is fine.
3. The OverlayNode class gets its own `to_dict()` method that makes `"NodeAttributes"` optional as well. All nodes have required NodeAttributes, so it's always written for a standard Node, but maybe you don't want to overlay NodeAttributes.

Plus some new `OverlayNode.to_dict()` tests. Thank you, Claude!

Edit: First attempt removed "default_node_name" as the name of the default node, but that was getting used in some other api functionality, so it was restored without change.